### PR TITLE
Adding monitoring to the environmental cake we bake.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,17 @@
 enablePlugins(JavaAppPackaging, DockerPlugin)
 
+val Http4sVersion = "0.20.1"
+val ZioVersion = "1.0-RC4"
+
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-zio" % "1.0-RC4",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "com.google.cloud" % "google-cloud-monitoring" % "1.74.0"
+  "org.scalaz"      %% "scalaz-zio"              % ZioVersion,
+  "org.scalaz"      %% "scalaz-zio-interop-cats" % ZioVersion,
+  "org.scalatest"   %% "scalatest"               % "3.0.5" % "test",
+  "com.google.cloud" % "google-cloud-monitoring" % "1.74.0",
+  "org.http4s"      %% "http4s-blaze-server"     % Http4sVersion,
+  "org.http4s"      %% "http4s-blaze-client"     % Http4sVersion,
+  "org.http4s"      %% "http4s-circe"            % Http4sVersion,
+  "org.http4s"      %% "http4s-dsl"              % Http4sVersion
 )
 
 dockerPermissionStrategy := com.typesafe.sbt.packager.docker.DockerPermissionStrategy.Run

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ enablePlugins(JavaAppPackaging, DockerPlugin)
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-zio" % "1.0-RC4",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+  "com.google.cloud" % "google-cloud-monitoring" % "1.74.0"
 )
 
 dockerPermissionStrategy := com.typesafe.sbt.packager.docker.DockerPermissionStrategy.Run

--- a/src/main/scala/Monitoring.scala
+++ b/src/main/scala/Monitoring.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.IOException
+
+import scalaz.zio.ZIO
+import com.google.cloud.monitoring.v3.MetricServiceClient
+import com.google.api.{Metric, MonitoredResource}
+import com.google.monitoring.v3.{
+    CreateTimeSeriesRequest,
+    Point,
+    ProjectName,
+    TimeInterval,
+    TimeSeries,
+    TypedValue
+}
+
+import com.google.protobuf.util.Timestamps
+
+trait Monitoring extends Serializable {
+    val monitoring: Monitoring.Service[Any]
+}
+object Monitoring extends Serializable {
+  trait Service[R] {
+      /** A custom metric where we increment the number of times we see a language. */
+      def languageVote(language: String): ZIO[R, IOException, Unit]
+  }
+
+  object NoMonitoring extends Monitoring {
+    override val monitoring: Service[Any] = new Service[Any] {
+      override def languageVote(language: String): ZIO[Any, IOException, Unit] =
+        ZIO.succeed(())  
+      }
+  }
+
+  /** This implementation provides a monitoring API using stackdriver. */
+  class StackDriverMonitoring(client: MetricServiceClient, projectId: String) extends Monitoring {
+    override val monitoring: Service[Any] = new Service[Any] {
+      
+      override def languageVote(language: String): ZIO[Any, IOException, Unit] = ZIO effect {
+        val name = ProjectName.of(projectId)
+        val labels = new java.util.HashMap[String, String]()
+        labels.put("language", language)
+        val metric = Metric.newBuilder()
+          .setType("custom.googleapis.com/survey/daily_votes")
+          .putAllLabels(labels)
+          .build()
+        val resourceLabels = new java.util.HashMap[String, String]
+        resourceLabels.put("project_id", projectId)
+        val resource = MonitoredResource.newBuilder.setType("global").putAllLabels(resourceLabels).build()
+        val interval = TimeInterval.newBuilder()
+          .setEndTime(Timestamps.fromMillis(System.currentTimeMillis()))
+          .build()
+        val point = Point.newBuilder.setInterval(interval).setValue(
+            TypedValue.newBuilder.setDoubleValue(1).build()
+        ).build()
+        val ts =
+          TimeSeries.newBuilder.setMetric(metric).setResource(resource).addPoints(point).build()
+        val request = 
+          CreateTimeSeriesRequest.newBuilder.setName(name.toString).addTimeSeries(ts).build()
+        client.createTimeSeries(request)
+      } refineOrDie {
+          case io: IOException => io
+          case other: Throwable => new IOException("Failed to log language metric", other)
+      }
+    }
+  }
+
+  object monitoring extends Monitoring.Service[Monitoring] {
+    override def languageVote(language: String): ZIO[Monitoring, IOException, Unit] =
+      ZIO.accessM[Monitoring](_.monitoring.languageVote(language))
+  }
+}

--- a/src/main/scala/MyApp.scala
+++ b/src/main/scala/MyApp.scala
@@ -28,8 +28,8 @@ object MyApp extends App {
   override def run(args: List[String]): ZIO[Clock, Nothing, Int] = {
     // TODO - check environment and start up as either webhook, or console.
     val runner =
-      if (args == List("-telnet")) myAppLogic.provideSomeM(telnetServerEnvironment)
-      else myAppLogic.provideSome(consoleEnvironment)
+      if (args == List("-telnet")) telnetServer
+      else consoleApp
     runner.fold(error => 1, result => 0)
   }
 
@@ -40,19 +40,23 @@ object MyApp extends App {
         override val conversation: Conversation.Service[Any] = Conversation.StdInOut.conversation
         override val monitoring: Monitoring.Service[Any] = Monitoring.NoMonitoring.monitoring
       }
-      
-  // TODO - def cloudEnvironment
 
-  /** Cconstructs a server environment that connects to a port and acts as a telnet server. */
-  def telnetServerEnvironment(clockService: Clock): ZIO[Any, Throwable, MyEnv] = {
-    ZIO.effect(new BadTelnetServer).map[MyEnv] { s =>
-      new Conversation with Clock with Monitoring {
-        override val clock: Clock.Service[Any] = clockService.clock
-        override val scheduler: Scheduler.Service[Any] = clockService.scheduler
-        override val conversation: Conversation.Service[Any] = new ZioServer(s)
-        override val monitoring: Monitoring.Service[Any] = Monitoring.NoMonitoring.monitoring
-      }
-    }
+  def consoleApp: ZIO[Clock, IOException, Unit] = myAppLogic.provideSome(consoleEnvironment)
+  def telnetServer: ZIO[Clock, IOException, Unit] = {
+    val server = for {
+      server <- ZioServer.listen(8022)
+      // TODO - make this be in parallel.
+      client <- ZioServer.accept(server)
+      result <- myAppLogic.provideSome[Clock] { clockService =>
+        new Conversation with Clock with Monitoring {
+         override val clock: Clock.Service[Any] = clockService.clock
+         override val scheduler: Scheduler.Service[Any] = clockService.scheduler
+         override val conversation: Conversation.Service[Any] = new ZioServer(new CpsTelnetServer(client))
+         override val monitoring: Monitoring.Service[Any] = Monitoring.NoMonitoring.monitoring
+        }
+      }.ensuring(ZIO.effectTotal(client.close))
+    } yield result
+    server.fold(error => 1, result => 0)
   }
 
   // Program logic.

--- a/src/main/scala/MyApp.scala
+++ b/src/main/scala/MyApp.scala
@@ -23,30 +23,25 @@ import scalaz.zio.clock.Clock
 import scalaz.zio.scheduler.Scheduler
 
 object MyApp extends App {
-
-  // TODO - add monitoring.
   type MyEnv = Conversation with Clock with Monitoring
 
   override def run(args: List[String]): ZIO[Clock, Nothing, Int] = {
     // TODO - check environment and start up as either webhook, or console.
-    asConsole(myAppLogic).fold(_ => 1, _ => 0)
+    myAppLogic.provideSome(consoleEnvironment).fold(error => 1, result => 0)
   }
 
-  def asConsole(app: ZIO[MyEnv, IOException, Unit]) =
-    myAppLogic.provideSome[Clock] { clockService =>
-      new Conversation with Clock with Monitoring {
+  def consoleEnvironment(clockService: Clock): MyEnv =
+    new Conversation with Clock with Monitoring {
         override val clock: Clock.Service[Any] = clockService.clock
         override val scheduler: Scheduler.Service[Any] = clockService.scheduler
         override val conversation: Conversation.Service[Any] = Conversation.StdInOut.conversation
         override val monitoring: Monitoring.Service[Any] = Monitoring.NoMonitoring.monitoring
       }
-    }
-  // TODO - def asCloud
-  // TODO - def asTest and test...
+  // TODO - def cloudEnvironment
 
 
+  // Program logic.
   val acceptableLanguages = Set("scala")
-
   val myAppLogic: ZIO[MyEnv, IOException, Unit] = {
     def validate(lang: String) = {
       if (acceptableLanguages(lang.toLowerCase)) {

--- a/src/main/scala/ZioServer.scala
+++ b/src/main/scala/ZioServer.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import scalaz.zio.ZIO
+ import java.io.IOException
+ import java.net.{Socket,ServerSocket}
+
+trait CpsServer {
+    /** Blocks the current thread until we get another spoken utterance and returns with the following.
+     * This will be empty for initial query. 
+     */
+    def onUserSpeech[R](continuation: String => R): Unit
+    /** Speaks back to the user. */
+    def say(msg: String): Unit
+}
+
+/** 
+ * This is an instance of an HTTP server for the google cloud hook that assumes we only ever have
+ * exactly one conversation.
+ *
+ *  All pending "say" events are queued and spit out if we have a connection.
+ *  All "read" events blocked until we have a result.
+ *
+ *  This class is highly mutable and wrong/bad.
+ *
+ * TODO - intatiate one of these PER CONNECTION, and run the app logic that way on an echo server.
+ */
+class BadTelnetServer(port: Int = 8022) extends CpsServer {
+   private val server = new java.net.ServerSocket(port) 
+   private var currentSocket: Option[Socket] = None
+
+   private def ensureConnection[A](f: Socket => A): A = {
+       currentSocket match {
+           case Some(socket) => ()
+           case None =>
+             currentSocket = Some(server.accept)
+       }
+       f(currentSocket.get)
+   }
+
+   def onUserSpeech[R](continuation: String => R): Unit = ensureConnection { socket =>
+       // TODO - read in socket.
+       val in = new java.io.BufferedReader(new java.io.InputStreamReader(socket.getInputStream))
+       continuation(in.readLine)
+   }
+
+   def say(msg: String): Unit = ensureConnection { socket =>
+       // TODO - send the message out the socket.
+       val out = new java.io.PrintWriter(socket.getOutputStream(), true)
+       out.println(msg)
+   }
+
+   def close(): Unit = {
+       currentSocket match {
+           case Some(socket) => socket.close()
+           case None => ()
+       }
+       // TODO - leave it open for another connection?
+       server.close()
+   }
+}
+
+/** Adapt the BadEchoServer into ZIO's algebra of effects/async. */
+class ZioServer(s: BadTelnetServer) extends Conversation.Service[Any] {
+      override def say(line: String): ZIO[Any, IOException, Unit] = {
+        ZIO.effect(s.say(line)).refineOrDie {
+          case e : IOException => e
+        }
+      }
+
+      override def listen: ZIO[Any, IOException, String] = {
+        ZIO.effectAsync[IOException, String] { callback =>
+          s onUserSpeech { said =>
+            callback(ZIO.succeed(said))
+          }
+        }
+      }
+}

--- a/src/test/scala/MyAppSpec.scala
+++ b/src/test/scala/MyAppSpec.scala
@@ -14,8 +14,60 @@
  * limitations under the License.
  */
 
+import java.io.IOException
 import org.scalatest.{FlatSpec, Matchers}
+import scalaz.zio.{ZIO, DefaultRuntime}
+import scalaz.zio.clock.Clock
+import scalaz.zio.scheduler.Scheduler
 
-class MyAppSpec extends FlatSpec with Matchers {
+/** Helper module to remember all logged languages in the Monitoring component. */
+class RecordingMonitorService extends Monitoring.Service[Any] {
+  private val recorded = collection.mutable.Set[String]()
+  override def languageVote(language: String): ZIO[Any, IOException, Unit] =
+           ZIO effectTotal {
+             recorded add language
+           }
+  def has(language: String): Boolean = recorded(language)          
+}
+/** Helper module to allow driving conversation by specifying only inputs. */
+class StaticConversation(inputs: Seq[String]) extends Conversation.Service[Any] {
+    // TODO - thread the index through here somehow, rather than hardcoding...
+    var idx = 0
+    override def say(s: String): ZIO[Any, IOException, Unit] = {
+      ZIO.succeed(())
+    }
 
+    override def listen: ZIO[Any, IOException, String] = {
+      ZIO.effect {
+          if (idx < inputs.length) {
+              val result = inputs(idx)
+              idx += 1
+              result
+          } else throw new IOException("Conversation was terminated")
+      } refineOrDie {
+          case io: IOException => io
+      }
+    }
+}
+
+class MyAppSpec extends FlatSpec with Matchers with DefaultRuntime {
+   "The conversation" must "record languages" in {
+     val recorder = new RecordingMonitorService
+     val staticConv = new StaticConversation(Seq("C#", "rust", "scala"))
+
+     val result = MyApp.myAppLogic.provideSome[Clock]({ clockService =>
+        new Conversation with Clock with Monitoring {
+            override val clock: Clock.Service[Any] = clockService.clock
+            override val scheduler: Scheduler.Service[Any] = clockService.scheduler
+            override val conversation: Conversation.Service[Any] = staticConv
+            override val monitoring: Monitoring.Service[Any] = recorder
+        }
+     }).fold(e => 1, a => 0)
+
+     assert(unsafeRun(result) == 0)
+     assert(recorder.has("scala"))
+     assert(recorder.has("rust"))
+     assert(recorder.has("C#"))
+     info("custom monitoring seems to work")
+  }
 }


### PR DESCRIPTION
- New monitoring API that allows us to record language votes
- "no monitoring" implementation for running on the console.
- A prototype implementation that fires way too many requests
  to stackdriver when unrecognized languages are seen.